### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,11 @@ PACKAGE            VERSION           DOWNLOADS           TESTS        COVERAGE
 
 
 
-.. |pip version| image:: https://pypip.in/v/djcron/badge.png
+.. |pip version| image:: https://img.shields.io/pypi/v/djcron.svg
     :target: https://pypi.python.org/pypi/djcron
     :alt: Latest PyPI version
 
-.. |pip downloads| image:: https://pypip.in/d/djcron/badge.png
+.. |pip downloads| image:: https://img.shields.io/pypi/dm/djcron.svg
     :target: https://pypi.python.org/pypi/djcron
     :alt: Number of PyPI downloads
 
@@ -49,11 +49,11 @@ PACKAGE            VERSION           DOWNLOADS           TESTS        COVERAGE
 
 
 
-.. |pip version s| image:: https://pypip.in/v/djcron-server/badge.png
+.. |pip version s| image:: https://img.shields.io/pypi/v/djcron-server.svg
     :target: https://pypi.python.org/pypi/djcron-server
     :alt: Latest PyPI version
 
-.. |pip downloads s| image:: https://pypip.in/d/djcron-server/badge.png
+.. |pip downloads s| image:: https://img.shields.io/pypi/dm/djcron-server.svg
     :target: https://pypi.python.org/pypi/djcron-server
     :alt: Number of PyPI downloads
 
@@ -71,11 +71,11 @@ PACKAGE            VERSION           DOWNLOADS           TESTS        COVERAGE
 
 
 
-.. |pip version a| image:: https://pypip.in/v/djcron-agent/badge.png
+.. |pip version a| image:: https://img.shields.io/pypi/v/djcron-agent.svg
     :target: https://pypi.python.org/pypi/djcron-agent
     :alt: Latest PyPI version
 
-.. |pip downloads a| image:: https://pypip.in/d/djcron-agent/badge.png
+.. |pip downloads a| image:: https://img.shields.io/pypi/dm/djcron-agent.svg
     :target: https://pypi.python.org/pypi/djcron-agent
     :alt: Number of PyPI downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20djcron))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `djcron`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.